### PR TITLE
Note on download of the A2L files

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -102,6 +102,9 @@ For example, this concerns information how to build the final A2L file, if the F
 The `A2L` description depends on the FMU binary, for example, regarding memory addresses, and byte order.
 If an FMU archive contains multiple binaries for different platforms, the associated A2L files are placed into separate subfolders below `/extra/org.modelica.fmi.layered_XCP` following the same scheme as in the `/binaries` folder, see <<Structure of the FMU archive>>.
 
+Note, that these `A2L` files are not intended to be downloaded to the simulator platform.
+_[Any files that are required on the simulator shall be handled as defined by the FMI standard via the `/resource` folder.]_
+
 `A2L` files may have a considerable size.
 If size is a concern, it may be decided to supply just a single platform and `A2L` file with an FMU.
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -102,7 +102,7 @@ For example, this concerns information how to build the final A2L file, if the F
 The `A2L` description depends on the FMU binary, for example, regarding memory addresses, and byte order.
 If an FMU archive contains multiple binaries for different platforms, the associated A2L files are placed into separate subfolders below `/extra/org.modelica.fmi.layered_XCP` following the same scheme as in the `/binaries` folder, see <<Structure of the FMU archive>>.
 
-Note, that the `A2L` files placed under the `extra` directory are not accessible to the FMU at run time.
+Note, that the `A2L` files placed under the `extra` directory are not accessible to the FMU at runtime.
 Any files that shall be accessible to the FMU at runtime must (also) be placed into the `resources` directory as defined by the FMI standard.
 
 `A2L` files may have a considerable size.

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -102,8 +102,8 @@ For example, this concerns information how to build the final A2L file, if the F
 The `A2L` description depends on the FMU binary, for example, regarding memory addresses, and byte order.
 If an FMU archive contains multiple binaries for different platforms, the associated A2L files are placed into separate subfolders below `/extra/org.modelica.fmi.layered_XCP` following the same scheme as in the `/binaries` folder, see <<Structure of the FMU archive>>.
 
-Note, that these `A2L` files are not intended to be downloaded to the simulator platform.
-_[Any files that are required on the simulator shall be handled as defined by the FMI standard via the `/resource` folder.]_
+Note, that the `A2L` files placed under the `extra` directory are not accessible to the FMU at run time.
+Any files that shall be accessible to the FMU at runtime must (also) be placed into the `resources` directory as defined by the FMI standard.
 
 `A2L` files may have a considerable size.
 If size is a concern, it may be decided to supply just a single platform and `A2L` file with an FMU.


### PR DESCRIPTION
I'm proposing to note that A2L files provided in the 'extra' folder are not downloaded to the simulator platform. Still the resource folder may be used to support use cases were A2L files may be needed on the platform.

@andreas-junghanns please review carefully considering the Silver workflow.

@PTaeuberDS @IZacharias please check.