### PR TITLE
- created example for ModelVariables in modelDescription.xml

### DIFF
--- a/docs/examples/model_variables_example.xml
+++ b/docs/examples/model_variables_example.xml
@@ -1,0 +1,27 @@
+<ModelVariables>
+
+  <Boolean name="org.fmi-standard.fmi-ls-xcp.EnableInternalXcpService"
+           valueReference="1"
+           causality="structuralParameter"
+           variability="fixed"
+           start="true"
+           description="Determines whether the internal XCP service shall be started.">
+  </Boolean>
+
+  <String name="org.fmi-standard.fmi-ls-xcp.ListenIpAddress"
+          valueReference="2"
+          causality="structuralParameter"
+          variability="fixed"
+          description="IP address where the XCP slave listens for XCP protocol commands.">
+    <Start value="127.0.0.1"/>
+  </String>
+
+  <UInt16 name="org.fmi-standard.fmi-ls-xcp.ListenPortNumber"
+          valueReference="3"
+          causality="structuralParameter"
+          variability="fixed"
+          start="32768"
+          description="Port number where the XCP slave listens for XCP protocol commands.">
+  </UInt16>
+
+</ModelVariables>


### PR DESCRIPTION
This is an example how I interpret the required configuration if an internal XCP slave. The XML schema requires a different kind of start value configuration for simple types (Boolean, UInt16) and strings. According to https://github.com/modelica/fmi-standard/blob/main/schema/fmi3Variable.xsd#L331 it is not enforced that exact one start value is given (minOccurs="0" maxOccurs="unbounded"). This should be described in the layered standard as an obligation of the importer.
I will take this a todo for me in addition to referring to the example in the document.