### PR TITLE
Mention CCLA explicitely in this layered standard.

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -528,7 +528,7 @@ Accessing variables in the memory of indirectly loaded dynamic libraries require
 - Markus S&#252;vern, dSPACE GmbH, Germany
 - Patrick T&#228;uber, dSPACE GmbH, Germany
 
-Contributions to this layered standard are covered by the [Corporate Contributors License Agreement (CCLA)](https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf) of the FMI Project.
+Contributions to this layered standard to the FMI standard are covered by the [Corporate Contributors License Agreement (CCLA)](https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf) of the Modelica Association Project FMI.
 
 [bibliography]
 == References

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -515,7 +515,7 @@ Limitations for binary FMUs:
 * Normally only variables in the memory segments owned by the main FMU binary `{.dll, .so}` are accessible by the XCP service, i.e., variables defined in source code modules and in statically linked libraries.
 Accessing variables in the memory of indirectly loaded dynamic libraries requires a special implementation which is out-of-scope for this layered standard.
 
-== Contributors 
+== Contributions
 
 - Christian Bertsch, Robert Bosch GmbH, Germany
 - Matthias Blesken, dSPACE GmbH, Germany
@@ -527,6 +527,8 @@ Accessing variables in the memory of indirectly loaded dynamic libraries require
 - Torsten Sommer, Dassault Syst&#232;mes, Germany
 - Markus S&#252;vern, dSPACE GmbH, Germany
 - Patrick T&#228;uber, dSPACE GmbH, Germany
+
+Contributions to this layered standard are covered by the [Corporate Contributors License Agreement (CCLA)](https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf) of the FMI Project.
 
 [bibliography]
 == References


### PR DESCRIPTION
I propose to explicitely state that this LS is covered by the CCLA of the FMI Project.

Currently the CCLA (https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf)  talks about " FMI Specifications distributed by the Modelica Association)", which to my understanding includes layered standards to the FMI standards release by he MAP FMI, and it  states "For the purposes of this definition, "submitted" means all the Works which are proposed by You in the form of an FMI Change Proposal (FCP) as defined within the FMI Development Process Rules of the Project." 
We will have to update the the development process rules of the FMI Project especially w.r.t to what an FCP is , which will take some time). In the meantime I would spell this out explicitly. https://github.com/modelica/fmi-design/issues/51